### PR TITLE
Change Button text to install

### DIFF
--- a/src/Views/permissions.blade.php
+++ b/src/Views/permissions.blade.php
@@ -14,7 +14,7 @@
 @if(!isset($permissions['errors']))
 <div class="buttons">
     <a class="button" href="{{ route('LaravelInstaller::database') }}">
-        {{ trans('messages.next') }}
+        {{ trans('messages.install') }}
     </a>
 </div>
 @endif


### PR DESCRIPTION
Installation for many migrations or large db:seed's can take a while - let user know that we're installing data now, not just going to the next step.

See PR #33 33