### PR TITLE
Force migrations on production environments + PT Portugal lang support

### DIFF
--- a/src/Helpers/DatabaseManager.php
+++ b/src/Helpers/DatabaseManager.php
@@ -26,7 +26,7 @@ class DatabaseManager
     private function migrate()
     {
         try{
-            Artisan::call('migrate');
+            Artisan::call('migrate', ["--force"=> true ]);
         }
         catch(Exception $e){
             return $this->response($e->getMessage());

--- a/src/Lang/pt/messages.php
+++ b/src/Lang/pt/messages.php
@@ -1,0 +1,69 @@
+<?php
+
+return [
+
+    /**
+     *
+     * Shared translations.
+     *
+     */
+    'title' => 'Instalador Laravel',
+    'next' => 'Próximo Passo',
+    'finish' => 'Instalar',
+
+
+    /**
+     *
+     * Home page translations.
+     *
+     */
+    'welcome' => [
+        'title'   => 'Bem-vindo ao Instalador',
+        'message' => 'Bem-vindo ao assistente de configuração.',
+    ],
+
+
+    /**
+     *
+     * Requirements page translations.
+     *
+     */
+    'requirements' => [
+        'title' => 'Requisitos',
+    ],
+
+
+    /**
+     *
+     * Permissions page translations.
+     *
+     */
+    'permissions' => [
+        'title' => 'Permissões',
+    ],
+
+
+    /**
+     *
+     * Environment page translations.
+     *
+     */
+    'environment' => [
+        'title' => 'Configurações de Ambiente',
+        'save' => 'Salvar .env',
+        'success' => 'Suas configurações de arquivo .env foram gravadas.',
+        'errors' => 'Não foi possível gravar o arquivo .env, por favor crie-o manualmente.',
+    ],
+
+
+    /**
+     *
+     * Final page translations.
+     *
+     */
+    'final' => [
+        'title' => 'Terminado',
+        'finished' => 'Aplicação foi instalada com sucesso',
+        'exit' => 'Clique aqui para sair',
+    ],
+];


### PR DESCRIPTION
This update is to let the migrations run when installing on production environments and a language file for the pt localization.
When on production, laravel ask for confirmation before migrating the database, which is not visible through the installer leading to an empty database after the install.