### PR TITLE
Add missing install text

### DIFF
--- a/src/Lang/en/messages.php
+++ b/src/Lang/en/messages.php
@@ -54,6 +54,8 @@ return [
         'success' => 'Your .env file settings have been saved.',
         'errors' => 'Unable to save the .env file, Please create it manually.',
     ],
+    
+    'install' => 'Install',
 
 
     /**


### PR DESCRIPTION
During the installation process, on the permissions page, the install button says 'message.install'. This will change that to simply "Install"