### PR TITLE
Direct to application home page on install

### DIFF
--- a/src/Views/finished.blade.php
+++ b/src/Views/finished.blade.php
@@ -4,6 +4,6 @@
 @section('container')
     <p class="paragraph">{{ session('message')['message'] }}</p>
     <div class="buttons">
-        <a href="/" class="button">{{ trans('messages.final.exit') }}</a>
+        <a href="{{ url('/') }}" class="button">{{ trans('messages.final.exit') }}</a>
     </div>
 @stop


### PR DESCRIPTION
If the user doesn't have a standard URL (ie. local setup without domain), the default code will go to the wrong page. This will grab the actual application's URL and load properly.