### PR TITLE
- Update feature apache requirements.

### DIFF
--- a/src/Config/installer.php
+++ b/src/Config/installer.php
@@ -20,7 +20,7 @@ return [
             'tokenizer',
         ],
         'apache' => [
-            'rewrite',
+            'mod_rewrite',
         ]
     ],
 

--- a/src/Helpers/RequirementsChecker.php
+++ b/src/Helpers/RequirementsChecker.php
@@ -15,30 +15,41 @@ class RequirementsChecker
     {
         $results = [];
 
-        foreach($requirements['php'] as $requirement)
+        foreach($requirements as $type => $requirement)
         {
-            $results['requirements'][$requirement] = true;
-
-            if(!extension_loaded($requirement))
-            {
-                $results['requirements'][$requirement] = false;
-
-                $results['errors'] = true;
-            }
-
-            if(!empty($requirements['apache']))
-            {
-                foreach ($requirements['apache'] as $requirement) {
-                    if(function_exists('apache_get_modules'))
+            switch ($type) {
+                // check php requirements
+                case 'php':
+                    foreach($requirements[$type] as $requirement)
                     {
-                        if(!in_array($requirement,apache_get_modules()))
+                        $results['requirements'][$type][$requirement] = true;
+
+                        if(!extension_loaded($requirement))
                         {
-                            $results['requirements'][$requirement] = true;
+                            $results['requirements'][$type][$requirement] = false;
+
+                            $results['errors'] = true;
                         }
                     }
-                }
-            }
+                    break;
+                // check apache requirements
+                case 'apache':
+                    foreach ($requirements[$type] as $requirement) {
+                        // if function doesn't exist we can't check apache modules
+                        if(function_exists('apache_get_modules'))
+                        {
+                            $results['requirements'][$type][$requirement] = true;
+                            
+                            if(!in_array($requirement,apache_get_modules()))
+                            {
+                                $results['requirements'][$type][$requirement] = false;
 
+                                $results['errors'] = true;
+                            }
+                        }
+                    }
+                    break;
+            }
         }
 
         return $results;

--- a/src/Views/requirements.blade.php
+++ b/src/Views/requirements.blade.php
@@ -2,11 +2,14 @@
 
 @section('title', trans('messages.requirements.title'))
 @section('container')
-    <ul class="list">
-        @foreach($requirements['requirements'] as $extention => $enabled)
-        <li class="list__item {{ $enabled ? 'success' : 'error' }}">{{ $extention }}</li>
-        @endforeach
-    </ul>
+    @foreach($requirements['requirements'] as $type => $requirement)
+        <h5>{{ ucfirst($type) }}</h5>
+        <ul class="list">
+            @foreach($requirements['requirements'][$type] as $extention => $enabled)
+                <li class="list__item {{ $enabled ? 'success' : 'error' }}">{{ $extention }}</li>
+            @endforeach
+        </ul>
+    @endforeach
 
     @if ( ! isset($requirements['errors']))
         <div class="buttons">


### PR DESCRIPTION
I'm sorry, i push pull request last night and i make big big mistake ^^ i make foreach for apache in foreach of php ...
I review my code and rewrite this with switch code.

Now in your installer you can declare components like that:
```
    'requirements' => [
        'php' => [
            'openssl',
            'pdo',
            'mbstring',
            'tokenizer',
        ],
        'apache' => [
            'mod_rewrite',
        ]
    ],
```

If webserver is not apache so code dont check apache requirements.
With this structure you can add more requirements system if you needed it.

I made some change in view requirements for make two list separed by type of requirements (apache or php)

![image](https://cloud.githubusercontent.com/assets/7473485/22264139/3e4ebee0-e277-11e6-9efb-aef7b6da998b.png)
