### PR TITLE
Added custom commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "rachidlaasri/laravel-installer",
+  "name": "oldu67/laravel-installer",
   "description": "Laravel web installer",
   "license": "MIT",
   "authors": [

--- a/src/Config/installer.php
+++ b/src/Config/installer.php
@@ -40,11 +40,18 @@ return [
         'bootstrap/cache/'       => '775'
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Migration and Custom Commands
+    |--------------------------------------------------------------------------
+    |
+    | This is the default Migrate and Seed process, if you want to add
+    | custom commands just add them to the array list bellow.
+    |
+    */
     'commands' => [
         'migrate',
         'db:seed',
-
-        //add custom commands
     ],
 
 

--- a/src/Config/installer.php
+++ b/src/Config/installer.php
@@ -38,5 +38,14 @@ return [
         'storage/framework/'     => '775',
         'storage/logs/'          => '775',
         'bootstrap/cache/'       => '775'
-    ]
+    ],
+
+    'commands' => [
+        'migrate',
+        'db:seed',
+
+        //add custom commands
+    ],
+
+
 ];

--- a/src/Controllers/DatabaseController.php
+++ b/src/Controllers/DatabaseController.php
@@ -28,7 +28,7 @@ class DatabaseController extends Controller
      */
     public function database()
     {
-        $response = $this->databaseManager->migrateAndSeed();
+        $response = $this->databaseManager->commands();
 
         return redirect()->route('LaravelInstaller::final')
                          ->with(['message' => $response]);

--- a/src/Helpers/DatabaseManager.php
+++ b/src/Helpers/DatabaseManager.php
@@ -23,7 +23,7 @@ class DatabaseManager
             try{
                 foreach (Config::get('installer.commands') as $command){
 
-                    Artisan::call($command , ["--force"=> true ]);
+                    Artisan::call($command);
                 }
             }
             catch(Exception $e){

--- a/src/Helpers/DatabaseManager.php
+++ b/src/Helpers/DatabaseManager.php
@@ -12,48 +12,26 @@ class DatabaseManager
 {
 
     /**
-     * Migrate and seed the database.
+     * Custom Commands
      *
      * @return array
      */
-    public function migrateAndSeed()
+    public function commands()
     {
-        $this->sqlite();
-        return $this->migrate();
-    }
+        if(is_array(Config::get('installer.commands'))) {
 
-    /**
-     * Run the migration and call the seeder.
-     *
-     * @return array
-     */
-    private function migrate()
-    {
-        try{
-            Artisan::call('migrate', ["--force"=> true ]);
-        }
-        catch(Exception $e){
-            return $this->response($e->getMessage());
+            try{
+                foreach (Config::get('installer.commands') as $command){
+
+                    Artisan::call($command , ["--force"=> true ]);
+                }
+            }
+            catch(Exception $e){
+                return $this->response($e->getMessage());
+            }
         }
 
-        return $this->seed();
-    }
-
-    /**
-     * Seed the database.
-     *
-     * @return array
-     */
-    private function seed()
-    {
-        try{
-            Artisan::call('db:seed');
-        }
-        catch(Exception $e){
-            return $this->response($e->getMessage());
-        }
-
-        return $this->response(trans('installer_messages.final.finished'), 'success');
+        return $this->response(trans('messages.final.finished'), 'success');
     }
 
     /**


### PR DESCRIPTION
I used my commands.
For example

 ```
   'commands' => [
        'migrate',
        'db:seed',
        'module:migrate',
        'module:seed',
        'migrate --path=vendor/venturecraft/revisionable/src/migrations'
    ],
```

or  my custom commands

```
   'commands' => [
        'baznews:install',
    ],
```

Maybe I want to add `Redis::flushall();` in my custom `baznews:install` command.
(App\Console\Commands)
