### PR TITLE
Auto-discovery fails on Laravel 5.5 due to incorrect path

### DIFF
--- a/src/Providers/LaravelInstallerServiceProvider.php
+++ b/src/Providers/LaravelInstallerServiceProvider.php
@@ -24,7 +24,7 @@ class LaravelInstallerServiceProvider extends ServiceProvider
     public function register()
     {
         $this->publishFiles();
-        $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
+        $this->loadRoutesFrom(__DIR__.'/../Routes/web.php');
     }
 
     /**


### PR DESCRIPTION
Path is wrong, so the service provider autodiscovery call fails. Not quite seeing this locally but for still fails on builds for completely fresh no vendor installs.

```php
Fatal error: Illuminate\Support\ServiceProvider::loadRoutesFrom(): Failed opening required '/project/path/vendor/rachidlaasri/laravel-installer/src/Providers/../routes/web.php' (include_path='.:/home/travis/.phpenv/versions/7.0.22/share/pear') in /project/path/vendor/laravel/framework/src/Illuminate/Support/ServiceProvider.php on line 71
```

Stack trace/build log here:
https://travis-ci.org/nabeelio/phpvms/jobs/311455947