### PR TITLE
Validation fail feedback

### DIFF
--- a/src/Controllers/EnvironmentController.php
+++ b/src/Controllers/EnvironmentController.php
@@ -87,12 +87,11 @@ class EnvironmentController extends Controller
             'environment_custom.required_if' => trans('installer_messages.environment.wizard.form.name_required'),
         ];
 
-        $validator = Validator::make($request->all(),$rules, $messages);
+        $validator = Validator::make($request->all(), $rules, $messages);
 
         if ($validator->fails()) {
-            $this->throwValidationException(
-                $request, $validator
-            );
+            $errors = $validator->errors();
+            return view('vendor.installer.environment-wizard', compact('errors', 'envConfig'));
         }
 
         $results = $this->EnvironmentManager->saveFileWizard($request);


### PR DESCRIPTION
The view is expecting the $errors file to contain the messages, just pass it and all validations are highlighted.

Before
![image](https://user-images.githubusercontent.com/4631227/34264107-12fe4f8a-e672-11e7-96e2-1c1aaf74debd.png)

After
![image](https://user-images.githubusercontent.com/4631227/34264405-1bf9ed6e-e673-11e7-84fa-ec3ae0efdbbf.png)
