### PR TITLE
Create a new EnvironmentSaved event

### DIFF
--- a/src/Controllers/EnvironmentController.php
+++ b/src/Controllers/EnvironmentController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use RachidLaasri\LaravelInstaller\Helpers\EnvironmentManager;
+use RachidLassri\LaravelInstaller\Events\EnvironmentSaved;
 use Validator;
 use Illuminate\Validation\Rule;
 
@@ -68,6 +69,8 @@ class EnvironmentController extends Controller
     public function saveClassic(Request $input, Redirector $redirect)
     {
         $message = $this->EnvironmentManager->saveFileClassic($input);
+        
+        event(new EnvironmentSaved($input));
 
         return $redirect->route('LaravelInstaller::environmentClassic')
                         ->with(['message' => $message]);
@@ -95,6 +98,8 @@ class EnvironmentController extends Controller
         }
 
         $results = $this->EnvironmentManager->saveFileWizard($request);
+        
+        event(new EnvironmentSaved($request));
 
         return $redirect->route('LaravelInstaller::database')
                         ->with(['results' => $results]);

--- a/src/Events/EnvironmentSaved.php
+++ b/src/Events/EnvironmentSaved.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace RachidLaasri\LaravelInstaller\Events;
+
+use Illuminate\Http\Request;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
+
+class EnvironmentSaved
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+    
+    public function getRequest()
+    {
+        return $this->request;
+    }
+}


### PR DESCRIPTION
This event allows users to customize the form installer with their own custom fields, and then after the environment has been saved, it allows them to interact with those fields by listening to the new event.

One example use case is adding user fields to the installation process, then using those to create the user.