### PR TITLE
Force DB Seed

### DIFF
--- a/src/Helpers/DatabaseManager.php
+++ b/src/Helpers/DatabaseManager.php
@@ -52,7 +52,7 @@ class DatabaseManager
     private function seed($outputLog)
     {
         try{
-            Artisan::call('db:seed', [], $outputLog);
+            Artisan::call('db:seed', ['--force' => true], $outputLog);
         }
         catch(Exception $e){
             return $this->response($e->getMessage(), 'error', $outputLog);


### PR DESCRIPTION
The DB seeder won't run in production environments without user input, or using the force operator. Packaging the installer in a distributable app means it's likely going to be in production. This change allows us to use Laravel DB Seeders to set up the initial DB post migration.