### PR TITLE
Use static:: instead of -> since the code is only called statically.

### DIFF
--- a/src/Helpers/FinalInstallManager.php
+++ b/src/Helpers/FinalInstallManager.php
@@ -37,7 +37,7 @@ class FinalInstallManager
             }
         }
         catch(Exception $e){
-            return $this->response($e->getMessage());
+            return static::response($e->getMessage(), $outputLog);
         }
 
         return $outputLog;
@@ -57,7 +57,7 @@ class FinalInstallManager
             }
         }
         catch(Exception $e){
-            return $this->response($e->getMessage());
+            return static::response($e->getMessage(), $outputLog);
         }
 
         return $outputLog;
@@ -70,7 +70,7 @@ class FinalInstallManager
      * @param collection $outputLog
      * @return array
      */
-    private function response($message, $outputLog)
+    private static function response($message, $outputLog)
     {
         return [
             'status' => 'error',


### PR DESCRIPTION
If any of the `Artisan::call` lines in `FinalInstallManager` fail, then we get a `Using $this when not in object context` error. 

This PR changes it to `static::` calls instead as well as changing the `response` method to static.